### PR TITLE
SDK and Gradle Update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,11 +40,11 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.0.0'
-    compile 'com.android.support:design:26.0.0'
-    compile 'com.squareup.okhttp3:okhttp:3.0.1'
-    compile 'com.android.support:support-v4:26.0.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:26.0.0'
+    implementation 'com.android.support:design:26.0.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.0.1'
+    implementation 'com.android.support:support-v4:26.0.0'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,15 +20,16 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 26
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "org.dharmaseed.androidapp"
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 26
         versionCode 6
         versionName "1.0.0-rc3"
+        vectorDrawables.useSupportLibrary = true
     }
     buildTypes {
         release {
@@ -41,8 +42,9 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.3.0'
-    compile 'com.android.support:design:23.3.0'
+    compile 'com.android.support:appcompat-v7:26.0.0'
+    compile 'com.android.support:design:26.0.0'
     compile 'com.squareup.okhttp3:okhttp:3.0.1'
-    compile 'com.android.support:support-v4:23.3.0'
+    compile 'com.android.support:support-v4:26.0.0'
 }
+

--- a/app/src/main/res/layout/app_bar_navigation.xml
+++ b/app/src/main/res/layout/app_bar_navigation.xml
@@ -64,7 +64,7 @@
         <ImageButton
             android:layout_width="30sp"
             android:layout_height="30sp"
-            android:src="@drawable/abc_ic_clear_mtrl_alpha"
+            android:src="@drawable/abc_ic_clear_material"
             android:background="@color/colorAccent"
             android:clickable="true"
             android:onClick="clearSearch" />

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -34,6 +35,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Apr 10 13:23:57 PDT 2016
+#Thu Jan 03 21:47:10 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Updates SDK and Gradle. One image resource stopped working after the update because the name changed, so I updated that.

I changed `compile` to `implementation` in `app/build.gradle` because `compile` is deprecated: https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations 

Once you pull this project into Android Studio and you have the latest Android Studio, it should resolve, download, and update everything for you. Let me know if you have any issues.