### PR TITLE
Move the call to start the load animation to `onPreExecute()`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Dharma Seed is dedicated to preserving and sharing the spoken teachings of Thera
 * Find talks by specific teachers
 * Search a teacher's talks by keyword
 * View teacher information
+* Download talks and listen without cellular or internet connectivity
 
 ## Screenshots
 
@@ -25,7 +26,6 @@ Dharma Seed is dedicated to preserving and sharing the spoken teachings of Thera
 
 ## Notes
 
-* The app does not currently support downloading talks for offline playing.
 * Access to retreatants only talks is not currently supported.
 
 These talks are freely offered in the spirit of dana, or generosity. You may visit the Dharma Seed website if you would like to support our work. We are a small non-profit organization supported solely through donations and we deeply appreciate your help in making these priceless teachings available to all.

--- a/app/src/main/java/org/dharmaseed/androidapp/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/androidapp/PlayTalkActivity.java
@@ -443,6 +443,14 @@ public class PlayTalkActivity extends AppCompatActivity
 
     public void startLoadingAnim() {
         ImageButton downloadButton = (ImageButton) findViewById(R.id.download_button);
+        // override the current listener so the user can't accidentally download the talk
+        // twice
+        downloadButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // do nothing
+            }
+        });
         Drawable icon = ContextCompat.getDrawable(this, R.drawable.ic_downloading);
         downloadButton.setImageDrawable(icon);
         if (icon instanceof Animatable)

--- a/app/src/main/java/org/dharmaseed/androidapp/PlayTalkActivity.java
+++ b/app/src/main/java/org/dharmaseed/androidapp/PlayTalkActivity.java
@@ -427,6 +427,9 @@ public class PlayTalkActivity extends AppCompatActivity
         dialog.show(getFragmentManager(), "DeleteTalkFragment");
     }
 
+    /**
+     * Deletes the talk from the FS and removes the path from the DB row
+     */
     public void deleteTalk() {
         if (!TalkManager.deleteTalk(talk)) {
             showToast("Unable to delete '" + talk.getTitle() + "'.", Toast.LENGTH_SHORT);
@@ -456,6 +459,7 @@ public class PlayTalkActivity extends AppCompatActivity
         Toast.makeText(getApplicationContext(), message, length).show();
     }
 
+
     @Override
     public void onDeleteTalkPositiveClick(DialogFragment dialogFragment) {
         deleteTalk();
@@ -474,8 +478,12 @@ public class PlayTalkActivity extends AppCompatActivity
         public DownloadTalkTask() {}
 
         @Override
-        protected Long doInBackground(Talk... talks) {
+        protected void onPreExecute() {
             startLoadingAnim();
+        }
+
+        @Override
+        protected Long doInBackground(Talk... talks) {
             long totalSize = 0;
             if (talks.length > 0) {
                 // only download the first one if we get passed multiple
@@ -487,7 +495,6 @@ public class PlayTalkActivity extends AppCompatActivity
 
         @Override
         protected void onPostExecute(Long size) {
-            // TODO change logs to show dialog
             if (size > 0) {
                 if (dbManager.addDownload(this.talk) == 1) {
                     showToast("'" + talk.getTitle() + "' downloaded.", Toast.LENGTH_SHORT);


### PR DESCRIPTION
This way, every talk that is downloaded gets the start animation, even if it is not _actually_ being downloaded at that moment (it is queued though). Also changes the click listener when we start the load animation, so the user can't spam download the same talk.

Also updates the README, because we do support downloading now 😄 .
